### PR TITLE
Improve ASP.NET open sourcing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This listing could not possibly be complete, so please open PRs with any additio
 * Codeplex supports git
 * Begins contributing to git and collaborates with GitHub on LibGit2
 * Ports Apache Hadoop to Windows, upstreams code under MIT 
-* Open sources ASP.NET, MCV, Razor, and Web API under Apache 2.0
+* Open sources ASP.NET (including MVC, Razor Pages, and Web API) under Apache 2.0
 * Forms Microsoft Open Technologies, Inc.
 * Releases TypeScript under Apache 2.0, first Microsoft project on GitHub
 * Canonical closes [Ubuntu bug #1](https://fridge.ubuntu.com/2013/05/31/mark-shuttleworth-closes-ubuntu-bug-1/)


### PR DESCRIPTION
Improve ASP.NET open sourcing text

- MCV should be MVC (unless we're referring to the Command & Conquer game's "Mobile Construction Vehicle" 🤔)
- MVC, Razor Pages, and Web API are all a part of the ASP.NET banner and should be listed as such using parentheses rather than as independent products
- Razor Pages is the product - clarify by adding "Pages" to "Razor"