### PR TITLE
Clarify that Wireless Display Adapter is Microsoft's first embedded linux device

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This listing could not possibly be complete, so please open PRs with any additio
 * The full .NET stack, Microsoft's flagship development toolkit, is open sourced and contributed to .NET Foundation
 * Creates official GitHub prescence
 * Implements AllJoyn support in Windows, contributes code upstream
-* Releases Wireless Display Adapter, first hardware device to use embedded Linux
+* Releases Wireless Display Adapter, Microsoft's first hardware device to use embedded Linux
 * Contributes to OpenJDK
 * 📺 "Microsoft loves Linux." - [Satya Nadella](https://www.youtube.com/watch?v=54hHr8ye2kE)
 * 📰 "More open-source at Microsoft? You'd better believe it" [VentureBeat](https://venturebeat.com/2014/10/20/microsoft-open-source/)


### PR DESCRIPTION
clarify that the Wireless Display Adapter is _Microsoft's_ first hardware device using embedded linux, not the first ever